### PR TITLE
Patch post message comms

### DIFF
--- a/app/javascript/sdk/IFrameHelper.js
+++ b/app/javascript/sdk/IFrameHelper.js
@@ -94,13 +94,16 @@ export const IFrameHelper = {
     );
   },
   initPostMessageCommunication: () => {
+    const allowedOrigin = new URL(IFrameHelper.baseUrl).origin;
+
     window.onmessage = e => {
+      if (e.origin !== allowedOrigin) return;
+
       if (
         typeof e.data !== 'string' ||
         e.data.indexOf('chatwoot-widget:') !== 0
-      ) {
-        return;
-      }
+      )  return;
+      
       const message = JSON.parse(e.data.replace('chatwoot-widget:', ''));
       if (typeof IFrameHelper.events[message.event] === 'function') {
         IFrameHelper.events[message.event](message);


### PR DESCRIPTION
Here's why we need to patch this:

1. On `app.latenthealth.com`, we run the script that fetches the Chatwoot SDK and runs it
2. This SDK creates an iframe pointed at `BASE_URL=chat.latenthealth.com/widget`
3. The `initPostMessageCommunications` creates a post message subscriber on the main application browser context (`app.latenthealth.com`). The received messages can technically come from any other tab in the browser, so it's essential we check that the origin of incoming postMessages are from `chat.latenthealth.com`

The potential cookie leak is via:
```
    popoutChatWindow: ({ baseUrl, websiteToken, locale }) => {
      const cwCookie = Cookies.get('cw_conversation');
      window.$chatwoot.toggle('close');
      popoutChatWindow(baseUrl, websiteToken, locale, cwCookie);
    },
```

This is one of the post message event handlers, so an attacker could craft a payload that triggers this `popoutChatWindow` handler with arbitrary data, such as opening the popup at an arbitrary domain, with the cookie in tow.